### PR TITLE
Use common syntax to refer to module methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ From `benchmark/symbol-to_s`
 
 ```
  Symbol#to_s (orig)     12.786M (± 1.5%) i/s -     64.032M in   5.009020s
-FString#symbol_to_s     20.371M (± 1.7%) i/s -    101.981M in   5.007706s
-       FString#to_s     19.086M (± 1.5%) i/s -     95.410M in   5.000016s
+FString.symbol_to_s     20.371M (± 1.7%) i/s -    101.981M in   5.007706s
+       FString.to_s     19.086M (± 1.5%) i/s -     95.410M in   5.000016s
 Symbol#to_s (patch)     21.669M (± 1.9%) i/s -    108.591M in   5.013331s
 ```
 

--- a/benchmark/symbol-to-s
+++ b/benchmark/symbol-to-s
@@ -9,7 +9,7 @@ FString.patch_symbol!
 
 Benchmark.ips do |bench|
   bench.report("Symbol#to_s (orig)") { :foo.id2name }
-  bench.report("FString#symbol_to_s") { FString.symbol_to_s(:foo) }
-  bench.report("FString#to_s") { FString.to_s(:foo) }
+  bench.report("FString.symbol_to_s") { FString.symbol_to_s(:foo) }
+  bench.report("FString.to_s") { FString.to_s(:foo) }
   bench.report("Symbol#to_s (patch)") { :foo.to_s }
 end


### PR DESCRIPTION
In documentation, we usually use a dot character to unambiguously refer to module methods as opposed to a hash character to refer to instance methods.