### PR TITLE
Add rake-compiler as a development dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,6 +18,8 @@ GEM
       concurrent-ruby (~> 1.0)
     minitest (5.11.3)
     rake (10.5.0)
+    rake-compiler (1.0.8)
+      rake
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
@@ -32,6 +34,7 @@ DEPENDENCIES
   bundler (~> 2.0)
   minitest (~> 5.0)
   rake (~> 10.0)
+  rake-compiler
   symbol-fstring!
 
 BUNDLED WITH

--- a/fstring.gemspec
+++ b/fstring.gemspec
@@ -40,4 +40,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "benchmark-ips", "~> 2.7"
   spec.add_development_dependency "activesupport"
+  spec.add_development_dependency "rake-compiler"
 end


### PR DESCRIPTION
Without it, a `bundle exec rake` results in the following error:

```
rake aborted!
LoadError: cannot load such file -- rake/extensiontask
Rakefile:12:in `require'
Rakefile:12:in `<top (required)>'
```