### PR TITLE
Add Ruby 3.1 - 3.3 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ ruby-head, '3.0', '2.7', '2.6', '2.5' ]
+        ruby: [ ruby-head, '3.3', '3.2', '3.1', '3.0', '2.7', '2.6', '2.5' ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
It's been a while since this has been updated.

Also bump the checkout action to v4 since I'm pretty sure this would either not work anymore or throw some deprecation warning.